### PR TITLE
chore: update minor version to v0.1.10

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@fold-dev/core",
     "title": "Fold",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "The UI library for product teams.",
     "main": "dist/index.js",
     "module": "dist/index.js",


### PR DESCRIPTION
This PR increments the minor version to 0.1.10. Why start at 0.1.10 and not 0.1.0? Because those versions were initially published to npm and then unpublished, however npm seems to keep a record of that version not being available to use anymore.