### PR TITLE
docs: add shorthand props to View component prop list

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -102,44 +102,157 @@ export type CoreViewProps = AriaAttributes & CommonProps & ShorthandProps & DOMA
 export type FormEvents = DOMAttributes<any>
 
 export type ShorthandProps = {
+    /**
+     * CSS hex color value
+     */
     bg?: string
+    /**
+     * CSS color token without the "--f-color-" prefix
+     */
     bgToken?: string
+    /**
+     * CSS hex color value
+     */
     color?: string
+    /**
+     * CSS color token without the "--f-color-" prefix
+     */
     colorToken?: string
+    /**
+     * CSS width
+     */
     width?: string | number
+    /**
+     * CSS height
+     */
     height?: string | number
+    /**
+     * CSS position
+     */
     position?: 'relative' | 'absolute' | 'fixed' | 'sticky' | 'static'
+    /**
+     * CSS display
+     */
     display?: 'block' | 'inline' | 'inline-block' | 'flex' | 'grid' | 'none'
+    /**
+     * CSS padding
+     */
     p?: string | number
+    /**
+     * CSS margin
+     */
     m?: string | number
+    /**
+     * CSS z-index
+     */
     zIndex?: string | number
+    /**
+     * CSS radius
+     */
     radius?: string | number
+    /**
+     * CSS blur
+     */
     blur?: string | number
+    /**
+     * CSS letter-spacing
+     */
     letterSpacing?: string | number
+    /**
+     * CSS line-height
+     */
     lineHeight?: string | number
+    /**
+     * CSS font-weight
+     */
     fontWeight?: string | number
+    /**
+     * CSS font-family
+     */
     font?: string
+    /**
+     * CSS font-size
+     */
     fontSize?: string | number
+    /**
+     * CSS text-decoration
+     */
     textDecoration?: 'none' | 'underline' | 'overline' | 'line-through' | 'underline' | string
+    /**
+     * CSS text-align
+     */
     textAlign?: string
+    /**
+     * CSS box-shadow
+     */
     shadow?: string | number
+    /**
+     * CSS border
+     */
     border?: string | number
+    /**
+     * CSS transition
+     */
     transition?: string | number
-    center?: boolean
+    /**
+     * add .f-row CSS class
+     */
     row?: boolean
+    /**
+     * add .f-col CSS class
+     */
     column?: boolean
+    /**
+     * CSS align-content
+     */
     alignContent?: FlexAlign
+    /**
+     * CSS align-items
+     */
     alignItems?: FlexAlign
+    /**
+     * CSS flex-basis
+     */
     basis?: string
+    /**
+     * CSS flex-direction
+     */
     flexDirection?: 'row ' | 'row-reverse' | 'column' | 'column-reverse'
+    /**
+     * CSS flex-grow
+     */
     grow?: string | number
+    /**
+     * CSS flex-shrink
+     */
     shrink?: string | number
+    /**
+     * CSS justify-content
+     */
     justifyContent?: FlexAlign
+    /**
+     * CSS flex-wrap
+     */
     wrap?: 'nowrap' | 'wrap' | 'wrap-reverse'
+    /**
+     * CSS flex
+     */
     flex?: number | string
+    /**
+     * CSS flow layout
+     */
     flow?: string
+    /**
+     * CSS flex alignment
+     */
     alignSelf?: FlexAlign
+    /**
+     * please see typedoc for align classes
+     */
     align?: ViewAlign
+    /**
+     * CSS flex gap
+     */
     gap?: number | string
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -102,7 +102,6 @@ export type CoreViewProps = AriaAttributes & CommonProps & ShorthandProps & DOMA
 export type FormEvents = DOMAttributes<any>
 
 export type ShorthandProps = {
-    theme?: string
     bg?: string
     bgToken?: string
     color?: string

--- a/packages/core/src/view/view.tsx
+++ b/packages/core/src/view/view.tsx
@@ -131,7 +131,6 @@ export const View = forwardRef((props: ViewProps, ref) => {
     const { getColorToken } = useTheme()
     const {
         as = 'div',
-        theme,
         bg,
         bgToken,
         color,
@@ -232,7 +231,6 @@ export const View = forwardRef((props: ViewProps, ref) => {
             className,
             style,
             ref,
-            'data-theme': props.theme,
         },
         props.children
     )

--- a/packages/core/src/view/view.tsx
+++ b/packages/core/src/view/view.tsx
@@ -154,7 +154,6 @@ export const View = forwardRef((props: ViewProps, ref) => {
         shadow,
         border,
         transition,
-        center,
         row,
         column,
         alignContent,

--- a/scripts/docgen/build.ts
+++ b/scripts/docgen/build.ts
@@ -16,21 +16,20 @@ const parserOptions: ParserOptions = {
     shouldIncludePropTagMap: true,
     propFilter: (prop: PropItem, component) => {        
         const { name, required, type, description, defaultValue, parent, declarations, tags } = prop
+
         if (!declarations) return false
+
         const declaration = declarations[0]
 
-        if (component.name == 'View') {
-            if (!declarations) return false
-            if (name.includes('aria-')) return false
-            if (name == 'key') return false
-            if (declaration.name == 'HTMLAttributes') return false
-            if (declaration.name == 'DOMAttributes') return false
-            if (declaration.name == 'AllHTMLAttributes') return false                    
-            return true
-        } else {    
-            const { fileName } = declaration
-            return !!fileName?.includes('.tsx')
-        }
+        if (name.includes('aria-')) return false
+        if (name == 'key') return false
+        if (declaration.name == 'HTMLAttributes') return false
+        if (declaration.name == 'DOMAttributes') return false
+        if (declaration.name == 'AllHTMLAttributes') return false           
+
+        return component.name == 'View' 
+            ? true 
+            : !!declaration.fileName?.includes('.tsx')
     },
 }
 
@@ -156,7 +155,6 @@ const generateMdx = (path) => {
                 !fileName.includes('.test') &&
                 !fileName.includes('fold.context')
             ) {
-                if (!fileName.includes('view')) return
                 console.log('exporting ', fileName)
 
                 const slug = fileName.replace('.tsx', '')
@@ -213,7 +211,6 @@ const generateMdx = (path) => {
             // hooks
             // -----------------------------
             if (fileName.includes('hooks')) {
-                return
                 console.log('exporting ', fileName)
 
                 const slug = fileName.replace('.stories.tsx', '')

--- a/scripts/docgen/build.ts
+++ b/scripts/docgen/build.ts
@@ -15,11 +15,25 @@ const parserOptions: ParserOptions = {
     savePropValueAsString: true,
     shouldIncludePropTagMap: true,
     propFilter: (prop: PropItem, component) => {
+        
         const { name, required, type, description, defaultValue, parent, declarations, tags } = prop
+
+        if (name.includes('aria-')) return false
+        if (name == 'key') return false
+        
         if (!declarations) return false
+
         const declaration = declarations[0]
-        const { fileName } = declaration
-        return !!fileName?.includes('.tsx')
+        const declarationName = declaration.name
+
+        if (declarationName == 'HTMLAttributes') return false
+        if (declarationName == 'DOMAttributes') return false
+        if (declarationName == 'AllHTMLAttributes') return false
+
+        
+                
+        return true
+        return !!declaration.fileName?.includes('.tsx')
     },
 }
 
@@ -145,6 +159,7 @@ const generateMdx = (path) => {
                 !fileName.includes('.test') &&
                 !fileName.includes('fold.context')
             ) {
+                if (!fileName.includes('view')) return
                 console.log('exporting ', fileName)
 
                 const slug = fileName.replace('.tsx', '')
@@ -201,6 +216,7 @@ const generateMdx = (path) => {
             // hooks
             // -----------------------------
             if (fileName.includes('hooks')) {
+                return
                 console.log('exporting ', fileName)
 
                 const slug = fileName.replace('.stories.tsx', '')

--- a/scripts/docgen/build.ts
+++ b/scripts/docgen/build.ts
@@ -14,26 +14,23 @@ const stripComments = (str) => str.replace(/\/\*[\s\S]*?\*\/|(?<=[^:])\/\/.*|^\/
 const parserOptions: ParserOptions = {
     savePropValueAsString: true,
     shouldIncludePropTagMap: true,
-    propFilter: (prop: PropItem, component) => {
-        
+    propFilter: (prop: PropItem, component) => {        
         const { name, required, type, description, defaultValue, parent, declarations, tags } = prop
-
-        if (name.includes('aria-')) return false
-        if (name == 'key') return false
-        
         if (!declarations) return false
-
         const declaration = declarations[0]
-        const declarationName = declaration.name
 
-        if (declarationName == 'HTMLAttributes') return false
-        if (declarationName == 'DOMAttributes') return false
-        if (declarationName == 'AllHTMLAttributes') return false
-
-        
-                
-        return true
-        return !!declaration.fileName?.includes('.tsx')
+        if (component.name == 'View') {
+            if (!declarations) return false
+            if (name.includes('aria-')) return false
+            if (name == 'key') return false
+            if (declaration.name == 'HTMLAttributes') return false
+            if (declaration.name == 'DOMAttributes') return false
+            if (declaration.name == 'AllHTMLAttributes') return false                    
+            return true
+        } else {    
+            const { fileName } = declaration
+            return !!fileName?.includes('.tsx')
+        }
     },
 }
 


### PR DESCRIPTION
This PR lists the shorthand props available on the View component when you navigate to the props list.

closes #41