### PR TITLE
feature: add ES6 module support for design tokens

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,8 +4,6 @@ const config: StorybookConfig = {
     stories: [
         '../packages/core/src/**/*.stories.tsx',
         '../packages/core/src/**/*.mdx',
-        '../packages/**/src/**/*.stories.tsx',
-        '../packages/**/src/**/*.mdx',
     ],
     addons: [
         '@storybook/addon-links', 

--- a/packages/design/config.js
+++ b/packages/design/config.js
@@ -144,8 +144,10 @@ module.exports = {
                 {
                     destination: 'tokens.js',
                     format: 'javascript/module-flat',
-                    // opted for a module
-                    // format: 'javascript/es6',
+                },
+                {
+                    destination: 'tokens-es6.js',
+                    format: 'javascript/es6',                    
                 },
             ],
         },


### PR DESCRIPTION
This PR will add ES6 design token modules & can be used as: 

``` typescript
import * as Token from '@fold-dev/design/tokens-es6'
```

