### PR TITLE
feat: Popover: portal support

### DIFF
--- a/packages/core/src/modal/modal.tsx
+++ b/packages/core/src/modal/modal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, forwardRef, useEffect, useRef } from 'react'
-import { ButtonProps, IconButton, View, useFocus, usePreventScrolling } from '../'
+import { ButtonProps, IconButton, PortalProps, View, useFocus, usePreventScrolling } from '../'
 import { classNames, getActionClass, getKey, mergeRefs } from '../helpers'
 import { CoreViewProps } from '../types'
 
@@ -43,7 +43,7 @@ export type ModalProps = {
     disableBackgroundEventPropagation?: boolean
     noOverlay?: boolean
     noDocumentScrolling?: boolean
-    portal?: any
+    portal?: (props: PortalProps) => React.ReactPortal
     onDismiss?: any
 } & CoreViewProps
 

--- a/packages/core/src/popover/popover.tsx
+++ b/packages/core/src/popover/popover.tsx
@@ -117,6 +117,31 @@ export const Popover = forwardRef((props: PopoverProps, ref) => {
         }
     }
 
+    const renderPopover = () => {
+        return (
+            <div
+                onKeyDown={handleKeyDown}
+                className="f-popover__anchor"
+                style={{
+                    transform: `translate(${box.left}px, ${box.top}px)`,
+                    width: box.width,
+                    height: box.height,
+                    position: isFixed  || !!portal ? 'fixed' : 'absolute',
+                }}
+                {...anchorProps}>
+                <View
+                    {...rest}
+                    tabIndex={0}
+                    onKeyDown={handleKeyDown}
+                    aria-describedby={id}
+                    className={className}
+                    ref={mergeRefs([ref, containerRef])}>
+                    {content}
+                </View>
+            </div>
+        )
+    }
+
     useEvent('click', handleClick, true)
     useEvent('keydown', handleKeyDownDocument, true)
 
@@ -129,8 +154,8 @@ export const Popover = forwardRef((props: PopoverProps, ref) => {
         const childRect = getBoundingClientRect(childEl)
         const popoverRect = getBoundingClientRect(popoverEl)
         const box = {
-            top: fixPosition ? fixPosition.top : childEl.offsetTop,
-            left: fixPosition ? fixPosition.left : childEl.offsetLeft,
+            top: fixPosition ? fixPosition.top : portal ? childRect.top : childEl.offsetTop,
+            left: fixPosition ? fixPosition.left : portal ? childRect.left : childEl.offsetLeft,
             width: fixPosition ? 1 : childEl.offsetWidth,
             height: fixPosition ? 1 : childEl.offsetHeight,
         }
@@ -162,7 +187,7 @@ export const Popover = forwardRef((props: PopoverProps, ref) => {
         }
 
         return () => containerRef.current?.style.removeProperty('top')
-    }, [showPopover, content, fixPosition, props.children, ready])
+    }, [showPopover, content, fixPosition, props.children, ready, portal])
 
     useEffect(() => {
         if (focusTrap && showPopover && containerRef.current) {
@@ -181,28 +206,13 @@ export const Popover = forwardRef((props: PopoverProps, ref) => {
                 })
             })}
 
-            {showPopover && (
-                <div
-                    onKeyDown={handleKeyDown}
-                    className="f-popover__anchor"
-                    style={{
-                        transform: `translate(${box.left}px, ${box.top}px)`,
-                        width: box.width,
-                        height: box.height,
-                        position: isFixed ? 'fixed' : 'absolute',
-                    }}
-                    {...anchorProps}>
-                    <View
-                        {...rest}
-                        tabIndex={0}
-                        onKeyDown={handleKeyDown}
-                        aria-describedby={id}
-                        className={className}
-                        ref={mergeRefs([ref, containerRef])}>
-                        {content}
-                    </View>
-                </div>
-            )}
+            {(showPopover && !portal) && renderPopover()}
+
+            {(showPopover && !!portal) && (
+                <props.portal>
+                    {renderPopover()}
+                </props.portal>
+            )}            
         </>
     )
 })

--- a/packages/core/src/popover/popover.tsx
+++ b/packages/core/src/popover/popover.tsx
@@ -1,5 +1,5 @@
 
-import React, { cloneElement, forwardRef, ReactElement, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import React, { cloneElement, forwardRef, ReactElement, ReactPortal, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useFocus, useId, View } from '..'
 import {
     classNames,
@@ -43,6 +43,7 @@ export type PopoverProps = {
     content?: ReactElement | any
     isVisible?: boolean
     onDismiss?: any
+    portal?: ReactPortal
 } & CoreViewProps
 
 export const Popover = forwardRef((props: PopoverProps, ref) => {
@@ -60,6 +61,7 @@ export const Popover = forwardRef((props: PopoverProps, ref) => {
         content,
         isVisible,
         onDismiss,
+        portal,
         ...rest
     } = props
     const containerRef = useRef(null)

--- a/packages/core/src/popover/popover.tsx
+++ b/packages/core/src/popover/popover.tsx
@@ -1,6 +1,6 @@
 
 import React, { cloneElement, forwardRef, ReactElement, ReactPortal, useEffect, useLayoutEffect, useRef, useState } from 'react'
-import { useFocus, useId, View } from '..'
+import { PortalProps, useFocus, useId, View } from '..'
 import {
     classNames,
     documentObject,
@@ -43,7 +43,7 @@ export type PopoverProps = {
     content?: ReactElement | any
     isVisible?: boolean
     onDismiss?: any
-    portal?: ReactPortal
+    portal?: (props: PortalProps) => React.ReactPortal
 } & CoreViewProps
 
 export const Popover = forwardRef((props: PopoverProps, ref) => {


### PR DESCRIPTION
closes #278 

This PR adds support for using a React Portal in the Popover component.