### PR TITLE
fix: display img as block

### DIFF
--- a/packages/core/src/image/image.css
+++ b/packages/core/src/image/image.css
@@ -23,7 +23,7 @@
 }
 
 .f-image img {
-    display: inline-block;
+    display: block;
     border-radius: inherit;
     object-fit: cover;
 }


### PR DESCRIPTION
This PR removes random space that sometimes gets added to the bottom of the image component.