### PR TITLE
fix: useLocalStorage: fix infinite render loop

### DIFF
--- a/packages/core/src/hooks/local-storage.hook.ts
+++ b/packages/core/src/hooks/local-storage.hook.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export function useLocalStorage<T>(key: string, initialValue: T) {
+    const keyCache = useRef(null)
     const [value, setValue] = useState<T>(() => {
         try {
             const stored = localStorage.getItem(key)
@@ -12,9 +13,14 @@ export function useLocalStorage<T>(key: string, initialValue: T) {
 
     // when key changes, reset value (don’t carry over old one)
     useEffect(() => {
+        const keyIsDifferent = keyCache.current != key
+
+        // if key is not different return
+        if (!keyIsDifferent) return
         try {
             const stored = localStorage.getItem(key)
             setValue(stored ? JSON.parse(stored) : initialValue)
+            keyCache.current = key
         } catch {
             setValue(initialValue)
         }

--- a/packages/core/src/tooltip/tooltip.tsx
+++ b/packages/core/src/tooltip/tooltip.tsx
@@ -84,6 +84,7 @@ export const Tooltip = (props: TooltipProps) => {
     const updateBox = () => setBox(getBoundingClientRect(childRef.current))
 
     const handleMouseEnter = (e) => {
+        if (e.currentTarget != childRef.current) return
         //focusElement(childRef.current)
         timeoutRef.current = setTimeout(() => {
             updateBox()
@@ -92,6 +93,8 @@ export const Tooltip = (props: TooltipProps) => {
     }
 
     const handleMouseDismiss = (e) => {
+        console.log(e.currentTarget, childRef.current)
+        if (e.currentTarget != childRef.current) return
         blurElement(childRef.current)
         clearInterval(timeoutRef.current)
         dismissTooltip()


### PR DESCRIPTION
This PR keeps track of the most recent key change so that the hook doesn't get put into an infinite render loop.