### PR TITLE
fix: Tooltip: check for propagation of DOM elements

### DIFF
--- a/packages/core/src/tooltip/tooltip.tsx
+++ b/packages/core/src/tooltip/tooltip.tsx
@@ -70,7 +70,7 @@ export const Tooltip = (props: TooltipProps) => {
     const timerRef = useRef(null)
     const timeoutRef = useRef(null)
     const id = useId()
-    const [isVisible, setVisible] = useState(false)
+    const [isVisible, setVisible] = useState(alwaysVisible)
     const [box, setBox] = useState<any>(null)
     const { setTimer, clearTimer } = useTimer()
     const showTooltip = box && (isVisible || alwaysVisible)
@@ -127,6 +127,13 @@ export const Tooltip = (props: TooltipProps) => {
             element.removeEventListener('blur', handleMouseDismiss)
         }
     }, [])
+
+    useEffect(() => {
+        if (alwaysVisible) {
+            updateBox()
+            setVisible(true)
+        }
+    }, [alwaysVisible])
 
     useLayoutEffect(() => {
         timerRef.current = showTooltip ? setInterval(updateBox, REPOSITION_INTERVAL) : null

--- a/packages/core/src/tooltip/tooltip.tsx
+++ b/packages/core/src/tooltip/tooltip.tsx
@@ -93,7 +93,7 @@ export const Tooltip = (props: TooltipProps) => {
 
     const handleMouseDismiss = (e) => {
         blurElement(childRef.current)
-        clearInterval(timeoutRef.current)
+        clearTimeout(timeoutRef.current)
         dismissTooltip()
     }
 
@@ -112,24 +112,21 @@ export const Tooltip = (props: TooltipProps) => {
     useEvent('keydown', handleKeyDown)
 
     useEffect(() => {
-        updateBox()
+        const element = childRef.current
+        if (!element) return
 
-        childRef.current?.addEventListener('focus', handleMouseEnter)
-        childRef.current?.addEventListener('mouseenter', handleMouseEnter)
-        childRef.current?.addEventListener('mouseleave', handleMouseDismiss)
-        childRef.current?.addEventListener('mouseout', handleMouseDismiss)
-        childRef.current?.addEventListener('mousedown', handleMouseDismiss)
-        childRef.current?.addEventListener('blur', handleMouseDismiss)
+        element.addEventListener('mouseenter', handleMouseEnter)
+        element.addEventListener('mouseleave', handleMouseDismiss)
+        element.addEventListener('focus', handleMouseEnter)
+        element.addEventListener('blur', handleMouseDismiss)
 
         return () => {
-            childRef.current?.removeEventListener('focus', handleMouseEnter)
-            childRef.current?.removeEventListener('mouseenter', handleMouseEnter)
-            childRef.current?.removeEventListener('mouseleave', handleMouseDismiss)
-            childRef.current?.removeEventListener('mouseout', handleMouseDismiss)
-            childRef.current?.removeEventListener('mousedown', handleMouseDismiss)
-            childRef.current?.removeEventListener('blur', handleMouseDismiss)
+            element.removeEventListener('mouseenter', handleMouseEnter)
+            element.removeEventListener('mouseleave', handleMouseDismiss)
+            element.removeEventListener('focus', handleMouseEnter)
+            element.removeEventListener('blur', handleMouseDismiss)
         }
-    }, [props.children])
+    }, [])
 
     useLayoutEffect(() => {
         timerRef.current = showTooltip ? setInterval(updateBox, REPOSITION_INTERVAL) : null


### PR DESCRIPTION
This PR fixes the clearance of Timeout (not Interval) and also cleans up the event handlers for detecting mouse overs.