### PR TITLE
fix: Menu: add missing event change handler

### DIFF
--- a/packages/core/src/menu/menu.tsx
+++ b/packages/core/src/menu/menu.tsx
@@ -103,6 +103,7 @@ export const MenuOptionGroup = (props: MenuOptionGroupProps) => {
     const handleClick = (value) => {
         if (checked.includes(value)) {
             setChecked(checked.filter((c) => c != value))
+            if (onChange) onChange(value)
         } else {
             if (type == 'checkbox') {
                 const newValue = [...checked, value]

--- a/packages/core/src/tooltip/tooltip.tsx
+++ b/packages/core/src/tooltip/tooltip.tsx
@@ -93,7 +93,6 @@ export const Tooltip = (props: TooltipProps) => {
     }
 
     const handleMouseDismiss = (e) => {
-        console.log(e.currentTarget, childRef.current)
         if (e.currentTarget != childRef.current) return
         blurElement(childRef.current)
         clearTimeout(timeoutRef.current)


### PR DESCRIPTION
This PR adds the `onChange` event handler to fire when the option is already checked.